### PR TITLE
fix: add styling for java code

### DIFF
--- a/_sass/custom/custom.scss
+++ b/_sass/custom/custom.scss
@@ -263,7 +263,8 @@ body {
         .language-html.highlighter-rouge,
         .language-csharp.highlighter-rouge,
         .language-jsx.highlighter-rouge,
-        .language-python.highlighter-rouge
+        .language-python.highlighter-rouge,
+        .language-java.highlighter-rouge
         {
             background-color: #1B1D32;
             code {


### PR DESCRIPTION
<!-- Describe your changes in detail -->
## Description

- Fix styling for `java` code examples, currently it looks like this:

![image](https://user-images.githubusercontent.com/9054729/155563075-f220ad94-e13f-41da-bbe1-3e18cdc06dd0.png)


<!-- Please describe in detail how teammates can test your changes. -->
## Testing required outside of automated testing?

- [ ] Not Applicable

<!-- Provide Screenshots when applicable -->
### Screenshots (if appropriate):

Now it looks like this:
![image](https://user-images.githubusercontent.com/9054729/155563254-562f58aa-ecfc-427d-8d8f-822f8985eae7.png)


- [ ] Not Applicable

<!-- Describe Rollback or Rollforward Procedure -->
## Rollback / Rollforward Procedure

- [ ] Roll Forward
- [ ] Roll Back

## Reviewer Checklist

- [ ] Description of Change
- [ ] Description of outside testing if applicable.
- [ ] Description of Roll Forward / Backward Procedure
- [ ] Documentation updated for Change
