### PR TITLE
feat: add callout to split card elements in guides

### DIFF
--- a/collections/guides/secure/collect-cards-with-elements-react.md
+++ b/collections/guides/secure/collect-cards-with-elements-react.md
@@ -19,6 +19,12 @@ Once you've completed this guide, you will have learned how your React applicati
 
 If you'd like to follow along with this guide from scratch, we suggest creating a new React sandbox using <a href="http://codesandbox.io/">codesandbox.io</a> and getting started from there! Want to jump right into our sample app? <a href="https://codesandbox.io/s/github/Basis-Theory/basis-theory-js-examples/tree/master/collect-cards-with-elements-react">Find it here!</a>
 
+<span class="base-alert info">
+  <span>
+    This guide is for collecting cards using the single `CardElement`. In case you prefer to have the card number, expiration date and cvc each in separate elements, check the docs on how to use them <a href="https://docs.basistheory.com/elements/#introduction">here</a> or check out our sample app <a href="https://codesandbox.io/embed/github/Basis-Theory/basis-theory-js-examples/tree/master/collect-cards-with-split-elements-react?module=/src/App.tsx,/src/CheckoutForm.tsx">here</a>.
+  </span>
+</span>
+
 ## Let's code
 
 <span class="base-alert warning">

--- a/collections/guides/secure/collect-cards-with-elements-react.md
+++ b/collections/guides/secure/collect-cards-with-elements-react.md
@@ -21,7 +21,7 @@ If you'd like to follow along with this guide from scratch, we suggest creating 
 
 <span class="base-alert info">
   <span>
-    This guide is for collecting cards using the single `CardElement`. In case you prefer to have the card number, expiration date and cvc each in separate elements, check the docs on how to use them <a href="https://docs.basistheory.com/elements/#introduction">here</a> or check out our sample app <a href="https://codesandbox.io/embed/github/Basis-Theory/basis-theory-js-examples/tree/master/collect-cards-with-split-elements-react?module=/src/App.tsx,/src/CheckoutForm.tsx">here</a>.
+    This guide is for collecting cards using the single `CardElement`. In case you prefer to have the card number, expiration date and cvc each in separate elements, check the docs on how to use them <a href="https://docs.basistheory.com/elements/#introduction">here</a> or check out our sample app <a href="https://codesandbox.io/embed/github/Basis-Theory/basis-theory-js-examples/tree/master/collect-cards-with-individual-elements-react?module=/src/App.tsx,/src/CheckoutForm.tsx">here</a>.
   </span>
 </span>
 

--- a/collections/guides/use/collect-cards-with-elements.md
+++ b/collections/guides/use/collect-cards-with-elements.md
@@ -146,6 +146,6 @@ Anything is possible when you store your card data with us. To expand your possi
 See a sample and the code that drives it below. Want to experience the sandbox yourself? [Check it out here.](https://codesandbox.io/s/github/Basis-Theory/basis-theory-js-examples/tree/master/collect-cards-with-elements)
 `
 <div class="iframe-container">
-  <iframe src="https://codesandbox.io/embed/github/Basis-Theory/basis-theory-js-examples/tree/master/collect-cards-with-elements?fontsize=14&hidenavigation=1&theme=dark&module=/public/index.html,/public/index.js,/api.js" class="iframe-code" allowfullscreen="" frameborder="0"></iframe>
+  <iframe src="https://codesandbox.io/embed/github/Basis-Theory/basis-theory-js-examples/blob/fd109ffbf62958d74956e9ac38a6d0b83dfa25b2/collect-cards-with-elements?fontsize=14&hidenavigation=1&theme=dark&module=/public/index.html,/public/index.js,/api.js" class="iframe-code" allowfullscreen="" frameborder="0"></iframe>
 </div>
 `

--- a/collections/guides/use/collect-cards-with-elements.md
+++ b/collections/guides/use/collect-cards-with-elements.md
@@ -24,7 +24,7 @@ Using React? Check out the [Collect Credit Cards with React Guide](/guides/colle
 
 <span class="base-alert info">
   <span>
-    This guide is for collecting cards using the single `CardElement`. In case you prefer to have the card number, expiration date and cvc each in separate elements, check the docs on how to use them <a href="https://docs.basistheory.com/elements/#introduction">here</a> or check out our sample app <a href="https://codesandbox.io/embed/github/Basis-Theory/basis-theory-js-examples/tree/master/collect-cards-with-split-elements?module=/public/index.html,/public/index.js,/api.js">here</a>.
+    This guide is for collecting cards using the single `CardElement`. In case you prefer to have the card number, expiration date and cvc each in separate elements, check the docs on how to use them <a href="https://docs.basistheory.com/elements/#introduction">here</a> or check out our sample app <a href="https://codesandbox.io/embed/github/Basis-Theory/basis-theory-js-examples/tree/master/collect-cards-with-individual-elements?module=/public/index.html,/public/index.js,/api.js">here</a>.
   </span>
 </span>
 

--- a/collections/guides/use/collect-cards-with-elements.md
+++ b/collections/guides/use/collect-cards-with-elements.md
@@ -22,6 +22,12 @@ If you'd like to follow along with this guide from scratch, we suggest creating 
 
 Using React? Check out the [Collect Credit Cards with React Guide](/guides/collect-cards-with-elements-react/).
 
+<span class="base-alert info">
+  <span>
+    This guide is for collecting cards using the single `CardElement`. In case you prefer to have the card number, expiration date and cvc each in separate elements, check the docs on how to use them <a href="https://docs.basistheory.com/elements/#introduction">here</a> or check out our sample app <a href="https://codesandbox.io/embed/github/Basis-Theory/basis-theory-js-examples/tree/master/collect-cards-with-split-elements?module=/public/index.html,/public/index.js,/api.js">here</a>.
+  </span>
+</span>
+
 ### Table of contents
 {: .no_toc .text-delta }
 1. 


### PR DESCRIPTION
<!-- Describe your changes in detail -->
## Description

- Adds callout to the use of split card elements in guides

⚠️ DO NOT MERGE BEFORE https://github.com/Basis-Theory/basis-theory-js-examples/pull/50

<!-- Please describe in detail how teammates can test your changes. -->
## Testing required outside of automated testing?

- [x] Not Applicable

<!-- Provide Screenshots when applicable -->
### Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/9054729/171258672-07921a18-962f-4da4-93c1-9f7fc975b834.png)

![image](https://user-images.githubusercontent.com/9054729/171258753-361cbaa7-a9ca-4884-9275-c708131a3b37.png)

- [ ] Not Applicable

<!-- Describe Rollback or Rollforward Procedure -->
## Rollback / Rollforward Procedure

- [x] Roll Forward
- [ ] Roll Back

## Reviewer Checklist

- [ ] Description of Change
- [ ] Description of outside testing if applicable.
- [ ] Description of Roll Forward / Backward Procedure
- [ ] Documentation updated for Change
