### PR TITLE
fix: use primary color for text selection and search dropdown

### DIFF
--- a/_sass/custom/custom.scss
+++ b/_sass/custom/custom.scss
@@ -629,3 +629,11 @@ body {
         margin-top: 25px;
     }
 }
+
+::selection { background: $primary-text; }
+
+a { color: $primary-dark; }
+
+.search-input:focus + .search-label .search-icon { color: $primary-dark; }
+
+.search-result-doc .search-result-icon { color: $primary-dark; }

--- a/_sass/custom/variables.scss
+++ b/_sass/custom/variables.scss
@@ -18,3 +18,4 @@ $info-bg: #1AD1DB !default;
 $danger-bg: #FB5B8B !default;
 $border-subtitles: rgba(65, 73, 112, 0.2);
 $dark-background-color: #070A1B;
+$link-color: $primary-dark !default;


### PR DESCRIPTION
<!-- Describe your changes in detail -->
## Description

- Fixes coloration of search dropdown and text selection

<!-- Please describe in detail how teammates can test your changes. -->
## Testing required outside of automated testing?

- [X] Not Applicable

<!-- Provide Screenshots when applicable -->
### Screenshots (if appropriate):

<img width="634" alt="image" src="https://user-images.githubusercontent.com/43392371/171665864-788acbb8-6027-4fe0-840c-5b17a9965a6b.png">

<img width="1107" alt="image" src="https://user-images.githubusercontent.com/43392371/171665926-4597dfff-91e9-4c9d-999a-bbdcac119724.png">

<!-- Describe Rollback or Rollforward Procedure -->
## Rollback / Rollforward Procedure

- [X] Roll Forward
- [ ] Roll Back

## Reviewer Checklist

- [ ] Description of Change
- [ ] Description of outside testing if applicable.
- [ ] Description of Roll Forward / Backward Procedure
- [ ] Documentation updated for Change
