### PR TITLE
feat: change react examples to use refs instead of getElement

### DIFF
--- a/collections/guides/secure/collect-cards-with-elements-react.md
+++ b/collections/guides/secure/collect-cards-with-elements-react.md
@@ -63,19 +63,23 @@ export default App;
 
 Create a `CheckoutForm` component and add it inside the `BasisTheoryProvider` in your `App` content.
 
+Create a `ref` that will be used to store the underlying elements instance.
+
 Declare a `CardElement` inside it and call the tokenization method `tokens.create` passing the token's type (card) and the underlying card element instance:
 
 ```jsx
+import { useRef } from 'react';
 import { CardElement, useBasisTheory } from '@basis-theory/basis-theory-react';
 
 export const CheckoutForm = () => {
   const { bt } = useBasisTheory();
+  const cardRef = useRef(null);
 
   const submit = async () => {
     try {
       const token = await bt.tokens.create({
         type: 'card',
-        data: bt?.getElement('myCard'),
+        data: cardRef.current,
       });
     } catch (error) {
       console.error(error);
@@ -84,7 +88,7 @@ export const CheckoutForm = () => {
 
   return (
     <>
-        <CardElement id="myCard" />
+        <CardElement id="myCard" ref={cardRef}/>
         <button
           id="submit_button"
           type="button"

--- a/collections/guides/secure/collect-pii-react.md
+++ b/collections/guides/secure/collect-pii-react.md
@@ -56,22 +56,27 @@ export default App;
 
 Create a `RegistrationForm` component and add it somewhere in your `App` content.
 
-Declare two `TextElement` tags inside it, one for the "Full Name", and the other for the "Social Security Number"; then call the `tokenize` method passing the underlying elements instances:
+Create two `refs` that will be used to store the underlying elements instances.
+
+Declare two `TextElement` tags inside it, one for the "Full Name", and the other for the "Social Security Number"; then call the `tokenize` method passing the current elements instance from the `refs`:
 
 
 ```jsx
+import { useRef } from 'react';
 import { TextElement, useBasisTheory } from '@basis-theory/basis-theory-react';
 
 export const RegistrationForm = () => {
   const { bt } = useBasisTheory();
+  const fullNameRef = useRef(null);
+  const ssnRef = useRef(null);
 
   const submit = async () => {
       try {
           const response = await bt.tokenize({
-              fullName: bt.getElement('fullName'),
+              fullName: fullNameRef.current,
               ssn: {
                   type: 'social_security_number',
-                  data: bt.getElement('ssn'),
+                  data: ssnRef.current,
               },
           });
       } catch (error) {
@@ -80,8 +85,8 @@ export const RegistrationForm = () => {
   };
   return (
     <>
-        <TextElement id="fullName" />
-        <TextElement id="ssn" />
+        <TextElement id="fullName" ref={fullNameRef} />
+        <TextElement id="ssn" ref={ssnRef} />
         <button
           id="submit_button"
           type="button"


### PR DESCRIPTION
<!-- Describe your changes in detail -->
## Description

- Changes react examples in guide to use new `refs` feature instead of `getElement`

<!-- Please describe in detail how teammates can test your changes. -->
## Testing required outside of automated testing?

- [x] Not Applicable

<!-- Provide Screenshots when applicable -->
### Screenshots (if appropriate):

![image](https://user-images.githubusercontent.com/9054729/186691014-2e57b21c-8f07-4293-a430-7e7ab3909467.png)

![image](https://user-images.githubusercontent.com/9054729/186690931-1729c2bc-147d-47d9-99d8-32579af59ad0.png)

- [ ] Not Applicable

<!-- Describe Rollback or Rollforward Procedure -->
## Rollback / Rollforward Procedure

- [x] Roll Forward
- [ ] Roll Back

## Reviewer Checklist

- [ ] Description of Change
- [ ] Description of outside testing if applicable.
- [ ] Description of Roll Forward / Backward Procedure
- [ ] Documentation updated for Change
